### PR TITLE
Truncate deposits to PPT

### DIFF
--- a/fee_redistribution.py
+++ b/fee_redistribution.py
@@ -93,7 +93,7 @@ class FeeRedistributionAtWithdrawlConstantTime:
         self.reward_ppt_initial[address] = self.reward_ppt_total
 
         # update total
-        self.principal_total += amount
+        self.principal_total += amount / PPT * PPT
 
     def withdraw(self, address):
         if address not in self.principal:
@@ -108,8 +108,8 @@ class FeeRedistributionAtWithdrawlConstantTime:
         # clear user account
         self.principal[address] = 0
         self.reward_ppt_initial[address] = 0
-        is_last_withdrawal = principal == self.principal_total
-        self.principal_total -= principal
+        is_last_withdrawal = principal / PPT * PPT == self.principal_total
+        self.principal_total -= principal / PPT * PPT
 
         # update total reward and remainder
         if not is_last_withdrawal:

--- a/fee_redistribution.py
+++ b/fee_redistribution.py
@@ -108,21 +108,21 @@ class FeeRedistributionAtWithdrawlConstantTime:
         # clear user account
         self.principal[address] = 0
         self.reward_ppt_initial[address] = 0
-        is_last_withdrawal = principal / PPT * PPT == self.principal_total
         self.principal_total -= principal / PPT * PPT
 
         # update total reward and remainder
-        if not is_last_withdrawal:
+        if self.principal_total > 0:
             amount = fee + self.reward_remainder  # wei
             base = self.principal_total / PPT # T wei
-
-            if base == 0:
-                self.reward_remainder = amount
-            else:
-                ratio = amount / base  # 1 / T
-                self.reward_ppt_total += ratio
-                self.reward_remainder = amount % base  # wei
+            # Note: principal_total > 0 results there's at least one deposit
+            # amount in the total; but any deposit >= PPT; hence base > 0
+            # So the below division is safe.
+            ratio = amount / base  # 1 / T
+            self.reward_ppt_total += ratio
+            self.reward_remainder = amount % base  # wei
         else:
+            assert self.principal_total == 0
+
             # special case for last withdrawal: no fee
             fee = 0
             reward += self.reward_remainder

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 import unittest
+import random
 
 
 from fee_redistribution import (
@@ -127,6 +128,28 @@ class TestFeeRedistribution(unittest.TestCase):
             r = tb.withdraw(address)
             total_withdraw += r
         self.assertEqual(total_withdraw, N * S * ETHER2WEI)
+
+
+    def test_random(self):
+        tb = TestKlass()
+        N = 10000
+        total_deposit = 0
+        for i in range(N):
+            address = "X" + str(i)
+            amount_eth = random.randint(1, 100000)
+            amount_wei = random.randint(1, ETHER2WEI - 1)
+
+            total_deposit += amount_eth * ETHER2WEI + amount_wei
+            tb.deposit(address, ether=amount_eth, wei=amount_wei)
+
+        total_withdraw = 0
+        for i in range(N):
+            address = "X" + str(i)
+            r = tb.withdraw(address)
+            total_withdraw += r
+
+        self.assertEqual(total_withdraw, total_deposit)
+
 
     def test_sequence(self):
         self.test_five_users()


### PR DESCRIPTION
Only amount eligible for reward is truncated; otherwise the original deposit amount is stored